### PR TITLE
feature/docker_precompile: Precompile the Rust build into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y nodejs npm
 
 RUN cargo install trunk
 
-# Create mount point for certificates  
+# Create mount point for certificates
 VOLUME /.cache/webui-privaxy
 
 # Set working directory
@@ -21,7 +21,7 @@ COPY . /app
 RUN cd web_frontend && npm i && npm install -g trunk && trunk build --release
 
 # Build the server
-RUN cd privaxy && cargo build --release
+RUN cd privaxy && cargo build --release --bin privaxy
 
-# Set the entrypoint to run privaxy
-CMD cargo run --release --bin privaxy
+# Set the entrypoint to run the precompiled privaxy binary
+CMD ["/app/target/release/privaxy"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a fork of [Privaxy](https://github.com/Barre/privaxy) v
 
 The front end code expects the `IP_ADDRESS` environment variable to be defined, otherwise it will default to `0.0.0.0` which will break functionality when used remotely. The `IP_ADDRESS` variable should be set to the IP address of the server running the container. This can be defined either in the `docker-compose.yml` file, when running the container manually with docker run, or as an environment variable when using the prebuilt image.
 
+The current network settings has to be `--network host` or else binding to the host IP address will not work. This is a limitation of the current codebase and will be fixed in the future by shifting to relative URI paths rather than hard coded IP addresses.
+
 ### Persistence
 
 Since everything is dockerized, the cert and keys need to stored somewhere so that new ones do not get generated when you restart an image. The codebase is modified to save the files in `/.cache/webui-privaxy`. You can mount any local folder or volume to that location. If you ever find the need to generate a fresh set of certificates and keys, you can do so by simply deleting this folder in your local environment.
@@ -22,11 +24,9 @@ Since everything is dockerized, the cert and keys need to stored somewhere so th
 3.  ```bash
     docker run -d \
        --name webui-privaxy \
-       -p 8000:8000 \
-       -p 8100:8100 \
-       -p 8200:8200 \
-       -e "IP_ADDRESS=<SERVER IP ADDRESS>"
-       -v $HOME/.cache/webui-privaxy:/.cache/webui-privaxy
+       --network host \
+       -e "IP_ADDRESS=<SERVER IP ADDRESS>" \
+       -v $HOME/.cache/webui-privaxy:/.cache/webui-privaxy \
        webui-privaxy
     ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
     volumes:
       - $HOME/.cache/webui-privaxy:/.cache/webui-privaxy
     image: ghcr.io/deetungsten/webui-privaxy:latest
-    ports:
-      - "8000:8000"
-      - "8100:8100"
-      - "8200:8200"
+    network_mode: "host"
     environment:
       - IP_ADDRESS=0.0.0.0


### PR DESCRIPTION
Docker Precompile - Changed so that the rust target is precompiled rather than compiled at container launch which saves a ton of time during boot

Dockerfile fix - Cannot bind to anything besides 0.0.0.0 when you use specific ports because of the Docker virtualization. We have to use `--network host` until I change the repo to use relative path rather than hardcoded address path.