### PR TITLE
Add arm64, armv7 build targets

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -28,6 +28,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: . # Path to the Dockerfile and build context (current directory)
+          platform: linux/amd64, linux/arm64, linux/arm/v7
           push: true # Push the image to the container registry
           tags: |
             ghcr.io/${{ github.repository_owner }}/webui-privaxy:latest

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Since everything is dockerized, the cert and keys need to stored somewhere so th
 
 ### Using prebuilt docker image
 
-1. Change the IP address to your server IP address `docker-compose.yml`
-2. `docker-compose up`
+1. Copy docker-compose.yml from github repository
+2. Change the IP address to your server IP address `docker-compose.yml`
+3. `docker compose up` or `docker compose up -d`
 
 ### Local
 


### PR DESCRIPTION
Adding arm64 and armv7 build targets so that any raspberry pi enthusiasts can deploy onto their system without tinkering.